### PR TITLE
Fixed success message in the scholarship detail page

### DIFF
--- a/frontend/src/components/SignIn/SignIn.tsx
+++ b/frontend/src/components/SignIn/SignIn.tsx
@@ -65,7 +65,6 @@ const SignInPage: React.FC<SignInPageProps> = () => {
     if (isAuthenticated) {
       switch (userState?.role?.id) {
         case 3:
-          navigate(window.location.pathname);
           break
         case 4:
           if (userState.scholarship_provider.provider_name) {

--- a/frontend/src/containers/ScholarshipDetailsPage/ScholarshipDetailsPage.tsx
+++ b/frontend/src/containers/ScholarshipDetailsPage/ScholarshipDetailsPage.tsx
@@ -236,6 +236,10 @@ export const ScholarshipDetailsPage: React.FC<
 
   useEffect(() => {
     handleModalSignInClose()
+    if(isModalSignInOpen) {
+      showMessage('You\'ve successfully logged in.', 'success');
+      handleModalSignInClose()
+    }   
   }, [isAuthenticated])
 
   useEffect(() => {


### PR DESCRIPTION
---
Fixed success message in the scholarship detail page
---

---

#### Feature Description
- A success message should show upon signing in from the sign in modal in the scholarship detail page.
---

#### Steps to Reproduce the Feature
Steps:
1. Access an individual scholarship page
2. Click on the Save or bookmark button
3. Sign in through the modal
4. A success message should show when the user has been authenticated.
---

#### Expected Behavior
- A success message should show when the user has been authenticated from the sign in modal.
---

#### Test Environment

- Browser: [e.g. Chrome, Safarri, Firefox]
- Test Scenarios:
  - [ ] Did the Test Feature Pass?
  - [ ] Did you check the features on different browsers?

---

#### Additional Details / Context

> Add any other context about the problem here.
